### PR TITLE
Remove unreasonable exclude to unblock v3 migration

### DIFF
--- a/dynamics-nav/docfx.json
+++ b/dynamics-nav/docfx.json
@@ -8,7 +8,6 @@
         ],
         "exclude": [
           "**/obj/**",
-          "../**",
           "**/includes/**",
           "**/_themes/**",
           "**/_themes.pdf/**",
@@ -28,7 +27,6 @@
         ],
         "exclude": [
           "**/obj/**",
-          "../**",
           "**/includes/**"
         ]
       }


### PR DESCRIPTION
../** means exclude all in parent folder. However, because current folder is docset folder and no content in parent folder will be included to publish. So ../** is not reasonable and we can remove that.

@edupont04 @SusanneWindfeldPedersen Please help to review.

cc @cillroy