### PR TITLE
Fix content links of picture schema in contracts

### DIFF
--- a/dynamics-nav/api-reference/v1.0/contracts/BCOAS1.0.yaml
+++ b/dynamics-nav/api-reference/v1.0/contracts/BCOAS1.0.yaml
@@ -10605,11 +10605,16 @@ components:
       nullable: true
       description: The contentType property for the Dynamics 365 Business Central picture entity
       maxLength: 100
-    content:
+    content@odata.mediaEditLink:
       type: string
-      format: binary
+      format: uri
       nullable: true
-      description: The content property for the Dynamics 365 Business Central picture entity
+      description: The content@odata.mediaEditLink property for the Dynamics 365 Business Central picture entity
+    content@odata.mediaReadLink:
+      type: string
+      format: uri
+      nullable: true
+      description: The content@odata.mediaReadLink property for the Dynamics 365 Business Central picture entity
   salesInvoiceLine:
    type: object
    properties:


### PR DESCRIPTION
The contract was not compliant with the [documentation](https://docs.microsoft.com/en-us/dynamics-nav/api-reference/v1.0/api/dynamics_picture_get) and the actual output of the endpoint. When I generated an api client from the specification, I had no way to get the picture links. This PR fixes that issue.