### PR TITLE
#2118 Example is wrong in "Formatting the Data in a Field"

### DIFF
--- a/dynamics-nav/Formatting-the-Data-in-a-Field.md
+++ b/dynamics-nav/Formatting-the-Data-in-a-Field.md
@@ -49,7 +49,7 @@ This topic describes how you can format the appearance of decimal data types in 
 |-------------------------|----------------------------|--------------------------------|----------------------------|  
 |0|\<Sign>\<Integer Thousand>\<Point or Comma>\<Decimals>|-76.543,21|-76,543.21|  
 |1|\<Sign>\<Integer>\<Point or Comma>\<Decimals>|-76543,21|-76543.21|  
-|2|\<Sign>\<Integer>\<Point or Comma>\<Decimals>|-76543.21|-76543.21|  
+|2|\<Sign>\<Integer>\<Point>\<Decimals>|-76543.21|-76543.21|  
 |3|\<Integer Thousand>\<Point or Comma>\<Decimals>\<Sign>|76.543,21-|76,543.21-|  
 |4|\<Integer>\<Decimals>\<Point or Comma>\<Sign>|76543,21-|76543.21-|  
 |9|XML format|-76543.21|-76543.21|  


### PR DESCRIPTION
In the "Standard Formats" table the third example (Standard Format = 2) is wrong.
<Sign><Integer><Point or Comma><Decimals>
but it should be
<Sign><Integer><Point><Decimals>