### PR TITLE
Removed unused local var of code example

### DIFF
--- a/dynamics-nav/TYPE-Function--FieldRef-.md
+++ b/dynamics-nav/TYPE-Function--FieldRef-.md
@@ -37,7 +37,6 @@ Type := FieldRef.TYPE
 |-------------------|--------------|  
 |CustomerRecref|RecordRef|  
 |MyFieldRef|FieldRef|  
-|varType|Variant|  
   
 |Text constant|ENU value|  
 |-------------------|---------------|  


### PR DESCRIPTION
Local variable "varType" removed, because it's not used/needed in the code example.